### PR TITLE
Ignore pdf.js files in Babel

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,15 +4,14 @@ var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
-    
-    // Add options here
-    
     minifyJS: {
       options: {
         exclude: ["**/pdf.worker.js"]
       }
+    },
+    babel: {
+      ignore: ['pdf.js', 'pdf.worker.js']
     }
-
   });
 
   /*


### PR DESCRIPTION
Speed up builds by ignoring pdf.js files