### PR TITLE
Add support for password protected PDF files to ember-pdfjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,47 @@ or
 
 `[model.src]` can be a `Uint8Array`, as `PDFJS` allows this as a source type for the `...getDocument()` signature.
 
+### Password Protected PDF Support
+
+The addon also allows for the registration of an Ember action handler for use when a PDF is password protected.  In a template
+you would add an action closure:
+
+````
+{{pdf-document src=[model.src] onPassword=(action 'myPasswordAction')}}
+
+````
+
+The associated action handler would look something like the following:
+
+````
+import { PasswordResponses } from 'ember-pdfjs/components/pdf-document';
+
+export default Ember.Controller.extend({
+    actions: {
+        'myPasswordAction': function(setPassword, reason) {
+            // The reason value provides an indication of first prompt
+            // versus incorrect password prompt
+            let promptText = 'Enter the password to open this PDF file.';
+            if (reason === PasswordResponses.INCORRECT_PASSWORD) {
+                promptText = 'Invalid password. Please try again.';
+            }
+            
+            // Prompt the user for their password in some application-specific way
+            let password = promptUserForPassword(promptText);
+            
+            // Callback with the password received from the prompt
+            setPassword(password);
+        }
+    }
+});
+````
+
+The action receives two parameters:
+ * setPassword - A callback function that is used to set the password received from the user
+ * reason - The "reason" that the password is being requested.  One of:
+   * PasswordResponses.NEED_PASSWORD (First time prompt)
+   * PasswordResponses.INCORRECT_PASSWORD (Re-prompt when previous password was incorrect)
+
 ### Note on Security
 You will get errors and it will not load if you try to link to something not hosted on your domain. You will need to update `contentSecurityPolicy` in your Ember project accordingly.
 

--- a/addon/components/pdf-document.js
+++ b/addon/components/pdf-document.js
@@ -182,6 +182,10 @@ export default Ember.Component.extend({
       let uri = get(this, 'src');
       let loadingTask = get(this, 'pdfLib').getDocument(uri);
 
+      loadingTask.onPassword = (updateCallback, reason) => {
+          this.sendAction('onPassword', updateCallback, reason);
+      };
+
       loadingTask.onProgress = (progressData) => {
         let percentLoaded = (100 * progressData.loaded / progressData.total);
         set(this, 'percentLoaded', percentLoaded);

--- a/addon/components/pdf-document.js
+++ b/addon/components/pdf-document.js
@@ -39,9 +39,22 @@ const { Promise } = Ember.RSVP;
 /* jshint undef: false */
 const {
   PDFLinkService,
-  PDFViewer
+  PDFViewer,
+  PasswordResponses
 } = PDFJS;
 /* jshint undef: true */
+
+/*
+  The following exports the values as of early 2017.
+
+ var PasswordResponses = {
+ NEED_PASSWORD: 1,
+ INCORRECT_PASSWORD: 2
+ };
+
+ */
+
+export { PasswordResponses };
 
 // Probably will need something like this for window resize, debounce.
 // const $window = Ember.$(window);

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ember-cli-babel": "^5.1.7"
   },
   "devDependencies": {
+    "broccoli-funnel": "1.1.0",
     "ember-ajax": "^2.4.1",
     "ember-cli": "2.11.1",
     "ember-cli-app-version": "^2.0.0",


### PR DESCRIPTION
The attached commits add support to ember-pdfjs to call an application-supplied action handler when a password is required to view a PDF file.  The implemented approach seemed the best way to meet up with the "Ember way", however happy to discuss changes to the approach.